### PR TITLE
feat: Implement Rummy game initial setup and game selection

### DIFF
--- a/card_game_app/lib/app_router.dart
+++ b/card_game_app/lib/app_router.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:card_game_app/features/main_menu/presentation/pages/main_menu_page.dart';
-import 'package:card_game_app/features/new_game/presentation/pages/new_game_page.dart';
+// import 'package:card_game_app/features/new_game/presentation/pages/new_game_page.dart'; // Removed
 import 'package:card_game_app/features/options/presentation/pages/options_page.dart';
 import 'package:card_game_app/features/about/presentation/pages/about_page.dart';
+import 'package:card_game_app/features/game_selection/presentation/pages/game_type_selection_page.dart'; // Added
+import 'package:card_game_app/features/rummy_game/presentation/pages/rummy_game_page.dart'; // Added
 
 // TODO: Define routes
 class AppRouter {
@@ -11,7 +13,9 @@ class AppRouter {
       case '/':
         return MaterialPageRoute(builder: (_) => const MainMenuPage());
       case '/new_game':
-        return MaterialPageRoute(builder: (_) => const NewGamePage());
+        return MaterialPageRoute(builder: (_) => const GameTypeSelectionPage()); // Changed
+      case '/rummy_game': // Added
+        return MaterialPageRoute(builder: (_) => const RummyGamePage()); // Added
       case '/options':
         return MaterialPageRoute(builder: (_) => const OptionsPage());
       case '/about':

--- a/card_game_app/lib/core/models/deck.dart
+++ b/card_game_app/lib/core/models/deck.dart
@@ -1,0 +1,47 @@
+import 'dart:math'; // For Random
+import 'playing_card.dart';
+
+class Deck {
+  late List<PlayingCard> _cards;
+
+  // Constructor: Initializes _cards with a standard 52-card deck.
+  Deck() {
+    _cards = [];
+    for (var suit in Suit.values) {
+      for (var rank in Rank.values) {
+        _cards.add(PlayingCard(suit: suit, rank: rank));
+      }
+    }
+  }
+
+  // Method shuffle(): Randomizes the order of cards in _cards.
+  void shuffle() {
+    _cards.shuffle(Random());
+  }
+
+  // Method deal(int numberOfCards):
+  // Removes numberOfCards from the end of _cards and returns them.
+  List<PlayingCard> deal(int numberOfCards) {
+    if (numberOfCards > _cards.length) {
+      // Or throw an exception, or return all remaining cards
+      numberOfCards = _cards.length; 
+    }
+    List<PlayingCard> dealtCards = _cards.sublist(_cards.length - numberOfCards);
+    _cards.removeRange(_cards.length - numberOfCards, _cards.length);
+    return dealtCards;
+  }
+
+  // Optional helper method isEmpty():
+  // Returns true if the deck has no cards.
+  bool get isEmpty => _cards.isEmpty;
+
+  // Optional helper method remainingCards():
+  // Returns the number of cards left in the deck.
+  int get remainingCards => _cards.length;
+
+  // For testing or verification purposes
+  @override
+  String toString() {
+    return 'Deck with $remainingCards cards remaining.';
+  }
+}

--- a/card_game_app/lib/core/models/playing_card.dart
+++ b/card_game_app/lib/core/models/playing_card.dart
@@ -1,0 +1,47 @@
+enum Suit {
+  hearts,
+  diamonds,
+  clubs,
+  spades,
+}
+
+enum Rank {
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  jack,
+  queen,
+  king,
+  ace,
+}
+
+class PlayingCard {
+  final Suit suit;
+  final Rank rank;
+
+  const PlayingCard({required this.suit, required this.rank});
+
+  @override
+  String toString() {
+    String rankStr = rank.toString().split('.').last;
+    String suitStr = suit.toString().split('.').last;
+    return '${rankStr[0].toUpperCase()}${rankStr.substring(1)} of ${suitStr[0].toUpperCase()}${suitStr.substring(1)}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PlayingCard &&
+          runtimeType == other.runtimeType &&
+          suit == other.suit &&
+          rank == other.rank;
+
+  @override
+  int get hashCode => suit.hashCode ^ rank.hashCode;
+}

--- a/card_game_app/lib/core/widgets/playing_card_widget.dart
+++ b/card_game_app/lib/core/widgets/playing_card_widget.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:card_game_app/core/models/playing_card.dart';
+
+// Helper functions (can be part of the class or outside)
+String getRankSymbol(Rank rank) {
+  switch (rank) {
+    case Rank.ace: return 'A';
+    case Rank.king: return 'K';
+    case Rank.queen: return 'Q';
+    case Rank.jack: return 'J';
+    case Rank.ten: return '10';
+    case Rank.nine: return '9';
+    case Rank.eight: return '8';
+    case Rank.seven: return '7';
+    case Rank.six: return '6';
+    case Rank.five: return '5';
+    case Rank.four: return '4';
+    case Rank.three: return '3';
+    case Rank.two: return '2';
+    default: return rank.toString().split('.').last[0].toUpperCase();
+  }
+}
+
+String getSuitSymbol(Suit suit) {
+  switch (suit) {
+    case Suit.hearts: return '♥';
+    case Suit.diamonds: return '♦';
+    case Suit.clubs: return '♣';
+    case Suit.spades: return '♠';
+    default: return '?';
+  }
+}
+
+Color getSuitColor(Suit suit) {
+  switch (suit) {
+    case Suit.hearts:
+    case Suit.diamonds:
+      return Colors.red;
+    default:
+      return Colors.black;
+  }
+}
+
+class PlayingCardWidget extends StatelessWidget {
+  final PlayingCard? card;
+  final bool isFaceUp;
+  final double width;
+  final double height;
+
+  const PlayingCardWidget({
+    super.key, // Changed from Key? key
+    this.card,
+    this.isFaceUp = true,
+    this.width = 60.0,
+    this.height = 90.0,
+  }); // : super(key: key); // Removed super(key:key) as it's handled by super.key
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: (isFaceUp && card != null) ? Colors.white : Colors.blueGrey,
+        borderRadius: BorderRadius.circular(8.0),
+        border: Border.all(color: Colors.black, width: 1.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            spreadRadius: 1,
+            blurRadius: 3,
+            offset: const Offset(1, 1),
+          ),
+        ],
+      ),
+      child: (isFaceUp && card != null)
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    getRankSymbol(card!.rank),
+                    style: TextStyle(
+                      fontSize: 20, // Adjust as needed
+                      fontWeight: FontWeight.bold,
+                      color: getSuitColor(card!.suit),
+                    ),
+                  ),
+                  Text(
+                    getSuitSymbol(card!.suit),
+                    style: TextStyle(
+                      fontSize: 18, // Adjust as needed
+                      color: getSuitColor(card!.suit),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : null, // No child for face-down or null card, just the background
+    );
+  }
+}

--- a/card_game_app/lib/features/game_selection/presentation/pages/game_type_selection_page.dart
+++ b/card_game_app/lib/features/game_selection/presentation/pages/game_type_selection_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class GameTypeSelectionPage extends StatelessWidget {
+  const GameTypeSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.gameTypeSelectionTitle),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushNamed(context, '/rummy_game');
+              },
+              child: Text(AppLocalizations.of(context)!.gameTypeRummy),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              AppLocalizations.of(context)!.gameTypeSolitaire,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            Text(
+              AppLocalizations.of(context)!.gameTypeDurak,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/card_game_app/lib/features/rummy_game/presentation/pages/rummy_game_page.dart
+++ b/card_game_app/lib/features/rummy_game/presentation/pages/rummy_game_page.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:card_game_app/core/models/deck.dart';
+import 'package:card_game_app/core/models/playing_card.dart';
+import 'package:card_game_app/core/widgets/playing_card_widget.dart';
+
+// Removed AnimatedCardData class
+
+class RummyGamePage extends StatefulWidget {
+  const RummyGamePage({super.key});
+
+  @override
+  State<RummyGamePage> createState() => _RummyGamePageState();
+}
+
+class _RummyGamePageState extends State<RummyGamePage> with SingleTickerProviderStateMixin {
+  late Deck _deck;
+  List<PlayingCard> _playerHandCards = []; // Stores all 10 cards for player
+  List<PlayingCard> _opponentHandCards = []; // Stores all 10 cards for opponent
+
+  late AnimationController _dealingAnimationController;
+  late Animation<int> _currentCardDealingAnimation;
+  
+  @override
+  void initState() {
+    super.initState();
+    _deck = Deck();
+    _deck.shuffle();
+
+    // Deal cards upfront to stable lists
+    _playerHandCards = _deck.deal(10);
+    _opponentHandCards = _deck.deal(10);
+
+    _dealingAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 3000), // e.g., 150ms per card for 20 cards
+      vsync: this,
+    );
+
+    _currentCardDealingAnimation = IntTween(begin: 0, end: 19).animate(_dealingAnimationController)
+      ..addListener(() {
+        setState(() {
+          // This will trigger build, which will use the animation value
+          // to determine how many cards to show from _playerHandCards and _opponentHandCards
+        });
+      });
+      // Removed addStatusListener for this simplified animation
+
+    _dealingAnimationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _dealingAnimationController.dispose();
+    super.dispose();
+  }
+
+  Widget _buildHandUI(List<PlayingCard> handCards, int cardsToShow, bool isPlayerHand) {
+    List<PlayingCard> visibleCards = [];
+    if (cardsToShow > 0 && cardsToShow <= handCards.length) {
+      visibleCards = handCards.sublist(0, cardsToShow);
+    } else if (cardsToShow > handCards.length) {
+      visibleCards = handCards; // Show all if animation value somehow exceeds count
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(8.0),
+      height: PlayingCardWidget.defaultHeight + 16, // Card height + padding
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: visibleCards.map((card) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4.0),
+              child: PlayingCardWidget(
+                card: card,
+                isFaceUp: isPlayerHand,
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    int animationValue = _currentCardDealingAnimation.value;
+
+    // Determine number of cards to show for player
+    int numPlayerCardsToShow = 0;
+    if (animationValue >= 0) { // Card 0 is player's first
+      numPlayerCardsToShow = (animationValue / 2).floor() + 1;
+    }
+    if (numPlayerCardsToShow > 10) numPlayerCardsToShow = 10;
+
+    // Determine number of cards to show for opponent
+    int numOpponentCardsToShow = 0;
+    if (animationValue >= 1) { // Card 1 is opponent's first
+       numOpponentCardsToShow = ((animationValue -1) / 2).floor() + 1;
+    }
+    if (numOpponentCardsToShow > 10) numOpponentCardsToShow = 10;
+
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.rummyGameTitle),
+      ),
+      backgroundColor: const Color(0xFF35654d), // Green felt color
+      body: Column(
+        children: <Widget>[
+          // Opponent's Hand (Top)
+          _buildHandUI(_opponentHandCards, numOpponentCardsToShow, false),
+          const Spacer(), // Pushes opponent's hand to top, player's to bottom
+          // Player's Hand (Bottom)
+          _buildHandUI(_playerHandCards, numPlayerCardsToShow, true),
+        ],
+      ),
+    );
+  }
+}

--- a/card_game_app/lib/l10n/app_ar.arb
+++ b/card_game_app/lib/l10n/app_ar.arb
@@ -6,7 +6,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_de.arb
+++ b/card_game_app/lib/l10n/app_de.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_en.arb
+++ b/card_game_app/lib/l10n/app_en.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_es.arb
+++ b/card_game_app/lib/l10n/app_es.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_fr.arb
+++ b/card_game_app/lib/l10n/app_fr.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_he.arb
+++ b/card_game_app/lib/l10n/app_he.arb
@@ -6,7 +6,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_ja.arb
+++ b/card_game_app/lib/l10n/app_ja.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_ko.arb
+++ b/card_game_app/lib/l10n/app_ko.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_ru.arb
+++ b/card_game_app/lib/l10n/app_ru.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_tr.arb
+++ b/card_game_app/lib/l10n/app_tr.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/lib/l10n/app_zh.arb
+++ b/card_game_app/lib/l10n/app_zh.arb
@@ -5,7 +5,12 @@
   "mainMenuOptions": "Options",
   "mainMenuAbout": "About",
   "mainMenuTitle": "Main Menu",
-  "newGamePageTitle": "New Game",
+  "newGamePageTitle": "Select Game Type",
   "optionsPageTitle": "Options",
-  "aboutPageTitle": "About"
+  "aboutPageTitle": "About",
+  "gameTypeSelectionTitle": "Select Game Type",
+  "gameTypeRummy": "Rummy",
+  "gameTypeSolitaire": "Solitaire",
+  "gameTypeDurak": "Durak",
+  "rummyGameTitle": "Rummy"
 }

--- a/card_game_app/test/widget_test.dart
+++ b/card_game_app/test/widget_test.dart
@@ -3,14 +3,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:card_game_app/app_router.dart';
 import 'package:card_game_app/features/main_menu/presentation/pages/main_menu_page.dart';
-import 'package:card_game_app/features/new_game/presentation/pages/new_game_page.dart';
+// import 'package:card_game_app/features/new_game/presentation/pages/new_game_page.dart'; // Replaced by GameTypeSelectionPage
+import 'package:card_game_app/features/game_selection/presentation/pages/game_type_selection_page.dart';
+import 'package:card_game_app/features/rummy_game/presentation/pages/rummy_game_page.dart';
+import 'package:card_game_app/core/widgets/playing_card_widget.dart';
 import 'package:card_game_app/features/options/presentation/pages/options_page.dart';
 import 'package:card_game_app/features/about/presentation/pages/about_page.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() {
   // Helper function to pump the app with localization and routing
-  Future<void> pumpApp(WidgetTester tester, {String initialRoute = '/'}) async {
+  Future<void> pumpApp(WidgetTester tester, {String initialRoute = '/', Duration? settleDuration}) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: const [
@@ -25,7 +28,12 @@ void main() {
         initialRoute: initialRoute,
       ),
     );
-    await tester.pumpAndSettle(); // Wait for initial frame and any animations
+    // If a specific settleDuration is provided, use it. Otherwise, default pumpAndSettle.
+    if (settleDuration != null) {
+      await tester.pumpAndSettle(settleDuration);
+    } else {
+      await tester.pumpAndSettle();
+    }
   }
 
   group('MainMenuPage Rendering Tests', () {
@@ -49,16 +57,17 @@ void main() {
   });
 
   group('Navigation Tests', () {
-    testWidgets('Navigate to NewGamePage and back', (WidgetTester tester) async {
+    testWidgets('Navigate to GameTypeSelectionPage and back', (WidgetTester tester) async {
       await pumpApp(tester);
 
       // Tap "New Game" button
       await tester.tap(find.widgetWithText(ElevatedButton, 'New Game'));
       await tester.pumpAndSettle();
 
-      // Verify NewGamePage is displayed
-      expect(find.byType(NewGamePage), findsOneWidget);
-      expect(find.text('New Game'), findsOneWidget); // Page content/title
+      // Verify GameTypeSelectionPage is displayed
+      expect(find.byType(GameTypeSelectionPage), findsOneWidget);
+      // Title of GameTypeSelectionPage is "Select Game Type"
+      expect(find.text('Select Game Type'), findsOneWidget); 
 
       // Verify AppBar and back button
       expect(find.byType(AppBar), findsOneWidget);
@@ -70,7 +79,7 @@ void main() {
 
       // Verify back to MainMenuPage
       expect(find.byType(MainMenuPage), findsOneWidget);
-      expect(find.text('Main Menu'), findsOneWidget);
+      expect(find.text('Main Menu'), findsOneWidget); // Main Menu title
     });
 
     testWidgets('Navigate to OptionsPage and back', (WidgetTester tester) async {
@@ -94,7 +103,7 @@ void main() {
 
       // Verify back to MainMenuPage
       expect(find.byType(MainMenuPage), findsOneWidget);
-       expect(find.text('Main Menu'), findsOneWidget);
+      expect(find.text('Main Menu'), findsOneWidget); // Main Menu title
     });
 
     testWidgets('Navigate to AboutPage and back', (WidgetTester tester) async {
@@ -118,7 +127,70 @@ void main() {
 
       // Verify back to MainMenuPage
       expect(find.byType(MainMenuPage), findsOneWidget);
-      expect(find.text('Main Menu'), findsOneWidget);
+      expect(find.text('Main Menu'), findsOneWidget); // Main Menu title
+    });
+  });
+
+  group('GameTypeSelectionPage Tests', () {
+    testWidgets('GameTypeSelectionPage renders correctly', (WidgetTester tester) async {
+      await pumpApp(tester, initialRoute: '/new_game');
+
+      expect(find.byType(GameTypeSelectionPage), findsOneWidget);
+      expect(find.text('Select Game Type'), findsOneWidget); // AppBar title
+      expect(find.widgetWithText(ElevatedButton, 'Rummy'), findsOneWidget);
+      expect(find.text('Solitaire'), findsOneWidget);
+      expect(find.text('Durak'), findsOneWidget);
+    });
+
+    testWidgets('Navigate from MainMenu to GameTypeSelection to RummyGamePage', (WidgetTester tester) async {
+      await pumpApp(tester); // Start on MainMenuPage
+
+      // Navigate to GameTypeSelectionPage
+      await tester.tap(find.widgetWithText(ElevatedButton, 'New Game'));
+      await tester.pumpAndSettle();
+      expect(find.byType(GameTypeSelectionPage), findsOneWidget);
+
+      // Tap "Rummy" button
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Rummy'));
+      // Allow time for RummyGamePage initState and animation controller to potentially start
+      // but not necessarily for the full dealing animation yet.
+      await tester.pumpAndSettle(const Duration(milliseconds: 500)); 
+
+      // Verify RummyGamePage is displayed
+      expect(find.byType(RummyGamePage), findsOneWidget);
+      expect(find.text('Rummy'), findsOneWidget); // RummyGamePage AppBar title
+    });
+  });
+
+  group('RummyGamePage Tests', () {
+    testWidgets('RummyGamePage initial rendering, dealing animation, and card visibility', (WidgetTester tester) async {
+      await pumpApp(tester, initialRoute: '/rummy_game');
+
+      // Verify initial rendering
+      expect(find.byType(RummyGamePage), findsOneWidget);
+      expect(find.text('Rummy'), findsOneWidget); // AppBar title
+
+      // Verify background color
+      final Scaffold scaffold = tester.widget(find.byType(Scaffold));
+      expect(scaffold.backgroundColor, const Color(0xFF35654d));
+
+      // Wait for the dealing animation to complete (duration is 3000ms in RummyGamePage)
+      // Using pumpAndSettle with a duration slightly longer.
+      await tester.pumpAndSettle(const Duration(seconds: 4));
+
+      // Verify player's hand (10 face-up cards)
+      expect(
+        find.byWidgetPredicate((widget) => widget is PlayingCardWidget && widget.isFaceUp == true && widget.card != null),
+        findsNWidgets(10),
+        reason: "Should find 10 face-up cards for the player",
+      );
+
+      // Verify opponent's hand (10 face-down cards)
+      expect(
+        find.byWidgetPredicate((widget) => widget is PlayingCardWidget && widget.isFaceUp == false && widget.card != null),
+        findsNWidgets(10),
+        reason: "Should find 10 face-down cards for the opponent",
+      );
     });
   });
 }


### PR DESCRIPTION
This commit introduces the initial UI and logic for selecting and starting a Rummy game.

Key features:
- Game Type Selection:
    - Added a 'GameTypeSelectionPage' after 'New Game' on the main menu.
    - Options: "Rummy" (functional), "Solitaire", "Durak" (placeholders).
- Rummy Game Page:
    - Created 'RummyGamePage' with a green felt background.
    - Implemented 'PlayingCard' and 'Deck' models.
    - On page load, a deck is shuffled, and 10 cards are dealt to you and opponent.
- Card Display & Animation:
    - 'PlayingCardWidget' created to render cards (face-up/down).
    - Your hand (10 cards) displayed face-up at the bottom.
    - Opponent's hand (10 cards) displayed face-down at the top.
    - A simplified animation shows cards appearing one-by-one in hands. (Initial attempts at a more complex flying card animation were unsuccessful and were simplified to this approach).
- Localization:
    - All new UI text was added to .arb files for all supported languages (using English as placeholders for non-English translations).
    - I will prompt you to run 'flutter gen-l10n'.
- Widget Tests:
    - Tests for 'GameTypeSelectionPage' (rendering, navigation).
    - Tests for 'RummyGamePage' (rendering, card dealing animation outcome).